### PR TITLE
include/command.h: correct to use enum command_ret_t for cmd_process()

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -141,7 +141,7 @@ enum command_ret_t {
  *			is left unchanged.
  * @return 0 if the command succeeded, 1 if it failed
  */
-int cmd_process(int flag, int argc, char * const argv[],
+enum command_ret_t cmd_process(int flag, int argc, char * const argv[],
 			       int *repeatable);
 
 #endif	/* __ASSEMBLY__ */


### PR DESCRIPTION
The types of declaration cmd_process() are conflict in command.c and common.h, correct to use "enum command_ret_t" for the declaration in common.h to fix below compile error:

| command.c:515:20: error: conflicting types for 'cmd_process' due to enum/integer mismatch; have 'enum command_ret_t(int,  int,  char * const*, int *)' [-Werror=enum-int-mismatch]
|   515 | enum command_ret_t cmd_process(int flag, int argc, char * const argv[],
|       |                    ^~~~~~~~~~~
| In file included from include/image.h:50,
|                  from include/common.h:118,
|                  from command.c:28:
| include/command.h:144:5: note: previous declaration of 'cmd_process' with type 'int(int,  int,  char * const*, int *)'
|   144 | int cmd_process(int flag, int argc, char * const argv[],